### PR TITLE
Add usage example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,17 @@ munigeo
 
 `munigeo` is a reusable Django application for storing and accessing
 municipality-related geospatial data.
+
+## Usage
+Install this to your project with `pip install django-munigeo`,
+add `munigeo` to your `INSTALLED_APPS` setting.
+
+### Helsinki example
+Before you can get Helsinki, you will need the data for Finland first:
+```
+python manage.py geo_import finland --municipalities
+```
+then
+```
+python manage.py geo_import helsinki --divisions
+```


### PR DESCRIPTION
Adds some hopefully helpful notes. Mixed up `django-munigeo` with the actual `munigeo` name in INSTALLED_APPS and didn't realize that you need to import the country before the city.