### PR TITLE
Request all data in GeoJSON-format, preventing curve geometries

### DIFF
--- a/munigeo/importer/helsinki.py
+++ b/munigeo/importer/helsinki.py
@@ -248,7 +248,7 @@ class HelsinkiImporter(Importer):
                 sep = '&'
             else:
                 sep = '?'
-            url = wfs_url + sep + 'typeName=' + div['wfs_layer'] + '&' + "srsName=EPSG:%d" % PROJECTION_SRID
+            url = wfs_url + sep + 'typeName=' + div['wfs_layer'] + '&' + "srsName=EPSG:%d" % PROJECTION_SRID + '&' + "outputFormat=application/json"
             ds = DataSource(url)
         lyr = ds[0]
         assert len(ds) == 1


### PR DESCRIPTION
GDAL wrapper in Django cannot handle curve geometries. Easiest way
to prevent them being output is to request results in GeoJSON, which
cannot contain them.

The offender prompting this change were the service areas of health
stations in combination with non-archaic GDAL >= 2.

This might cause the WFS server to silently convert curve geometries
to their linear approximations. The alternative would be to miss those
geometries entirely.