### PR TITLE
Add more logging for helsinki importer

### DIFF
--- a/munigeo/importer/helsinki.py
+++ b/munigeo/importer/helsinki.py
@@ -315,7 +315,9 @@ class HelsinkiImporter(Importer):
 
     @db.transaction.atomic
     def import_addresses(self):
+
         wfs_url = 'http://kartta.hel.fi/ws/geoserver/avoindata/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=avoindata:PKS_osoiteluettelo&SRSNAME=EPSG:3067'
+        self.logger.info("import_addresses: instantiating WFS datasource")
         ds = DataSource(wfs_url)
         lyr = ds[0]
         assert len(ds) == 1
@@ -335,6 +337,7 @@ class HelsinkiImporter(Importer):
             muni_dict[muni.name_fi] = muni
 
             self.logger.info('Loading existing data for %s' % muni)
+
             streets = Street.objects.filter(municipality=muni)
             muni.streets_by_name = {}
             muni.streets_by_id = {}
@@ -354,6 +357,7 @@ class HelsinkiImporter(Importer):
         bulk_street_list = []
         count = 0
 
+        self.logger.debug("Starting to process data from WFS source")
         for feat in lyr:
             count += 1
             if count % 1000 == 0:
@@ -361,14 +365,14 @@ class HelsinkiImporter(Importer):
 
             street_name = feat.get('katunimi').strip()
             street_name_sv = feat.get('gatan').strip()
-
             num = feat.get('osoitenumero')
+
             if not num:
-                #self.logger.info(row)
+                self.logger.debug("Rejecting {}, due to {} not being valid street number".format(street_name, num))
                 continue
             else:
                 if num == '0':
-                    #self.logger.info(row)
+                    self.logger.debug("Rejecting {}, due to {} not being valid street number".format(street_name, num))
                     continue
 
             num2 = feat.get('osoitenumero2')
@@ -382,6 +386,7 @@ class HelsinkiImporter(Importer):
             muni = muni_dict[muni_name]
             street = muni.streets_by_name.get(street_name, None)
             if not street:
+                self.logger.debug("street {} not found in DB, creating it".format(street_name))
                 street = Street(name_fi=street_name, name=street_name, municipality=muni)
                 street.name_sv = street_name_sv
 
@@ -400,13 +405,14 @@ class HelsinkiImporter(Importer):
             addr = street.addrs.get(addr_id, None)
             location = convert_from_gk25(coord_n, coord_e)
             if not addr:
+                self.logger.debug("Street {} did not have address {}. Creating".format(street.name, addr_id))
                 addr = Address(street=street, number=num, number_end=num2, letter=letter)
                 addr.location = location.wkb
                 bulk_addr_list.append(addr)
                 street.addrs[addr_id] = addr
             else:
                 if addr._found:
-                    self.logger.warning("%s: Skipping duplicate" % addr)
+                    self.logger.warning("{}: is duplicate, skipping".format(addr))
                     continue
                 # if the location has changed for more than 10cm, save the new one.
                 assert addr.location.srid == location.srid, "SRID changed"
@@ -428,19 +434,19 @@ class HelsinkiImporter(Importer):
                 db.reset_queries()
 
         if bulk_addr_list:
-            self.logger.info("Saving %d new addresses" % len(bulk_addr_list))
+            self.logger.info("Saving {} new addresses".format(len(bulk_addr_list)))
             Address.objects.bulk_create(bulk_addr_list)
             bulk_addr_list = []
 
         for muni in muni_list:
             for s in muni.streets_by_name.values():
                 if not s._found:
-                    self.logger.info("Street %s removed" % s)
+                    self.logger.info("Street {} removed".format(s))
                     s.delete()
                     continue
                 for a in s.addrs.values():
                     if not a._found:
-                        self.logger.info("%s removed" % a)
+                        self.logger.info("Address {} removed".format(a))
                         a.delete()
 
     def import_pois(self):

--- a/munigeo/importer/helsinki.py
+++ b/munigeo/importer/helsinki.py
@@ -317,7 +317,7 @@ class HelsinkiImporter(Importer):
     def import_addresses(self):
 
         wfs_url = 'http://kartta.hel.fi/ws/geoserver/avoindata/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=avoindata:PKS_osoiteluettelo&SRSNAME=EPSG:3067'
-        self.logger.info("import_addresses: instantiating WFS datasource")
+        self.logger.info("instantiating WFS datasource")
         ds = DataSource(wfs_url)
         lyr = ds[0]
         assert len(ds) == 1
@@ -336,7 +336,7 @@ class HelsinkiImporter(Importer):
         for muni in muni_list:
             muni_dict[muni.name_fi] = muni
 
-            self.logger.info('Loading existing data for %s' % muni)
+            self.logger.info("Loading existing data for %s".format(muni))
 
             streets = Street.objects.filter(municipality=muni)
             muni.streets_by_name = {}
@@ -357,7 +357,7 @@ class HelsinkiImporter(Importer):
         bulk_street_list = []
         count = 0
 
-        self.logger.debug("Starting to process data from WFS source")
+        self.logger.info("Starting to process data from WFS source")
         for feat in lyr:
             count += 1
             if count % 1000 == 0:
@@ -386,7 +386,7 @@ class HelsinkiImporter(Importer):
             muni = muni_dict[muni_name]
             street = muni.streets_by_name.get(street_name, None)
             if not street:
-                self.logger.debug("street {} not found in DB, creating it".format(street_name))
+                self.logger.info("street {} not found in DB, creating it".format(street_name))
                 street = Street(name_fi=street_name, name=street_name, municipality=muni)
                 street.name_sv = street_name_sv
 
@@ -396,7 +396,7 @@ class HelsinkiImporter(Importer):
                 street.addrs = {}
             else:
                 if street.name_sv != street_name_sv:
-                    self.logger.warning("%s: %s -> %s" % (street, street.name_sv, street_name_sv))
+                    self.logger.warning("{}: {} -> {}".format(street, street.name_sv, street_name_sv))
                     street.name_sv = street_name_sv
                     street.save()
             street._found = True
@@ -412,7 +412,7 @@ class HelsinkiImporter(Importer):
                 street.addrs[addr_id] = addr
             else:
                 if addr._found:
-                    self.logger.warning("{}: is duplicate, skipping".format(addr))
+                    self.logger.debug("{}: is duplicate, skipping".format(addr))
                     continue
                 # if the location has changed for more than 10cm, save the new one.
                 assert addr.location.srid == location.srid, "SRID changed"

--- a/munigeo/importer/helsinki.py
+++ b/munigeo/importer/helsinki.py
@@ -317,7 +317,7 @@ class HelsinkiImporter(Importer):
     def import_addresses(self):
 
         wfs_url = 'http://kartta.hel.fi/ws/geoserver/avoindata/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=avoindata:PKS_osoiteluettelo&SRSNAME=EPSG:3067'
-        self.logger.info("instantiating WFS datasource")
+        self.logger.info("Loading master data from WFS datasource")
         ds = DataSource(wfs_url)
         lyr = ds[0]
         assert len(ds) == 1
@@ -336,7 +336,7 @@ class HelsinkiImporter(Importer):
         for muni in muni_list:
             muni_dict[muni.name_fi] = muni
 
-            self.logger.info("Loading existing data for %s".format(muni))
+            self.logger.info("Loading existing data for {}".format(muni))
 
             streets = Street.objects.filter(municipality=muni)
             muni.streets_by_name = {}
@@ -357,11 +357,11 @@ class HelsinkiImporter(Importer):
         bulk_street_list = []
         count = 0
 
-        self.logger.info("Starting to process data from WFS source")
+        self.logger.info("starting data synchronization")
         for feat in lyr:
             count += 1
             if count % 1000 == 0:
-                self.logger.info("%d processed" % count)
+                self.logger.debug("{} processed".format(count))
 
             street_name = feat.get('katunimi').strip()
             street_name_sv = feat.get('gatan').strip()
@@ -448,6 +448,8 @@ class HelsinkiImporter(Importer):
                     if not a._found:
                         self.logger.info("Address {} removed".format(a))
                         a.delete()
+
+        self.logger.info("synchronization complete")
 
     def import_pois(self):
         URL_BASE = 'http://www.hel.fi/palvelukarttaws/rest/v2/unit/?service=%d'

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-munigeo',
-    version='0.2.10',
+    version='0.2.11',
     packages=['munigeo'],
     include_package_data=True,
     license='BSD License',


### PR DESCRIPTION
Cleans up logging, making it (hopefully) more useful when address imports are run automatically and logged on the server.