### PR TITLE
Force WFS output format to JSON in Helsinki address importer

### DIFF
--- a/munigeo/importer/helsinki.py
+++ b/munigeo/importer/helsinki.py
@@ -309,8 +309,10 @@ class HelsinkiImporter(Importer):
 
     @db.transaction.atomic
     def import_addresses(self):
-
-        wfs_url = 'http://kartta.hel.fi/ws/geoserver/avoindata/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=avoindata:PKS_osoiteluettelo&SRSNAME=EPSG:3067'
+        wfs_url = 'http://kartta.hel.fi/ws/geoserver/avoindata/wfs?' \
+                  'SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&' \
+                  'TYPENAME=avoindata:PKS_osoiteluettelo&' \
+                  'SRSNAME=EPSG:3067&outputFormat=application/json'
         self.logger.info("Loading master data from WFS datasource")
         ds = DataSource(wfs_url)
         lyr = ds[0]


### PR DESCRIPTION
Previously the output format wasn't specified, which made the import
fail in some environments.