### PR TITLE
Address search: Evaluate whole string, not only first character

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 __pycache__
 django_munigeo.egg-info/
+.idea

--- a/munigeo/api.py
+++ b/munigeo/api.py
@@ -418,7 +418,7 @@ class AddressViewSet(GeoModelAPIView, viewsets.ReadOnlyModelViewSet):
 
         street = filters.get('street', None)
         if street is not None:
-            if street[0].isnumeric():
+            if street.isnumeric():
                 queryset = queryset.filter(street=street)
             else:
                 args = {}


### PR DESCRIPTION
Evaluating only first character is not enough for cases where street contains also other characters than numbers.