### PR TITLE
Bugfix/requests cache raises typeerror

### DIFF
--- a/munigeo/importer/athens.py
+++ b/munigeo/importer/athens.py
@@ -3,7 +3,6 @@ import os
 import csv
 #import unicodecsv
 import requests
-import requests_cache
 import io
 import json
 
@@ -90,6 +89,5 @@ class AthensImporter(Importer):
             self._import_citadel(muni, d)
 
     def import_pois(self):
-        requests_cache.install_cache('geo_import_athens')
         self.logger.info("Importing POIs from Citadel")
         self.import_pois_from_citadel()

--- a/munigeo/importer/manchester.py
+++ b/munigeo/importer/manchester.py
@@ -3,7 +3,6 @@ import os
 import csv
 #import unicodecsv
 import requests
-import requests_cache
 import io
 import json
 
@@ -153,7 +152,6 @@ class ManchesterImporter(Importer):
             self._import_citadel(muni, d)
 
     def import_pois(self):
-        requests_cache.install_cache('geo_import_man')
         self.logger.info("Importing POIs from Citadel")
         self.import_pois_from_citadel()
         # self.logger.info("Importing POIs from CSV")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 Django>=3.1
 djangorestframework
 requests
-requests-cache
 django-mptt
 django-modeltranslation
 six

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     install_requires=[
         'Django',
         'requests',
-        'requests_cache',
         'django_mptt',
         'django_modeltranslation',
         'six',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-munigeo',
-    version='0.2.68',
+    version='0.2.69',
     packages=['munigeo'],
     include_package_data=True,
     license='BSD License',


### PR DESCRIPTION
# Remove requests_cache
Removed requests-cache as it when imported raises TypeError in some
cases with python 3.10 and basically is not used.

### Breakodown

1. munigeo/importer/athens.py
2. munigeo/importer/manchester.py
3. requirements.txt
    * Removed requests_cache.
5. setup.py
   * Removed requests_cache and updated version to 0.2.69