### PR TITLE
GDAL 3.0 Coordinate transformation backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ saying that a timezone-naive date was passed to a `DateTimeField`.
 - helsinki importer: Reverted the change introduced in v0.3.6 which broke Helsinki division import
 - helsinki importer: Fixed empty field value handling
 - helsinki importer: Fixed crash with division types without a layer
-
+- GDAL 3.0 Coordinate transformation backwards compatibility
 
 ## [0.3.6] - 2020-05-08
 


### PR DESCRIPTION
Fix for issue [GDAL 3.0 Coordinate transformation backwards compatibility is broken #44](https://github.com/City-of-Helsinki/django-munigeo/issues/44)