### PR TITLE
Use gettext_lazy in models.py

### DIFF
--- a/munigeo/models.py
+++ b/munigeo/models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.gis.db import models
 from django.db.models.query import Q
 from mptt.models import MPTTModel, TreeForeignKey


### PR DESCRIPTION
Using regular gettext leads to a possible localization clash in apps which have munigeo as a dependency. For example running makemigrations on such an app that has a translation defined for "Name" results in a new migration being generated for munigeo. This in turn is undesirable for CI pipelines which would like to check migrations.

For more details, https://code.djangoproject.com/ticket/21498