### PR TITLE
smbackend: Import 'no parking' area data

### DIFF
--- a/munigeo/importer/helsinki.py
+++ b/munigeo/importer/helsinki.py
@@ -158,6 +158,13 @@ class HelsinkiImporter(Importer):
                 else:
                     extra_attr_dict[attr] = None
 
+        #
+        # import "Pysäköintikielto" (No Parking) as "class 7" for PARKING_CLASS_NAME_MAP to map it as specified.
+        #
+        if extra_attr_dict["class"] == "0" and extra_attr_dict["origin_name"] is None:
+            if feat.get("tyyppi") == "Pysäköintikielto":
+                extra_attr_dict["class"] = "7"
+
         attr_dict['extra'] = extra_attr_dict
 
         origin_id = attr_dict['origin_id']

--- a/munigeo/management/commands/update_parking_areas.py
+++ b/munigeo/management/commands/update_parking_areas.py
@@ -15,6 +15,7 @@ PARKING_CLASS_NAME_MAP = {
     4: "Maksullinen, pysäköinti sallittu 1 h tai 2 h",
     5: "Maksullinen, pysäköinti sallittu 4 h",
     6: "Maksullinen, ei aikarajoitusta",
+    7: "Pysäköintikielto",
 }
 
 


### PR DESCRIPTION
The 'no parking' information in the parking area origin data has class 0 and no origin name. Class 0 is mapped as "Other" in the `PARKING_CLASS_NAME_MAP`, but now the 'no parking' is needed in its own category. To be able to import it, so it can be mapped as needed, we need to manually catch it during import.