### PR TITLE
RATYK-17: use https instead of http in helsinki importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+### Fixed
+- Fix Helsinki importer urls
+
 ## [0.3.9] - 2023-08-22
 ### Fixed
 - Fix municipality url

--- a/munigeo/importer/helsinki.py
+++ b/munigeo/importer/helsinki.py
@@ -23,7 +23,7 @@ from munigeo.importer.base import Importer, register_importer
 
 from django.conf import settings
 
-MUNI_URL = "http://tilastokeskus.fi/meta/luokitukset/kunta/001-2013/tekstitiedosto.txt"
+MUNI_URL = "https://tilastokeskus.fi/meta/luokitukset/kunta/001-2013/tekstitiedosto.txt"
 
 # The Finnish national grid coordinates in TM35-FIN according to JHS-180
 # specification. We use it as a bounding box.
@@ -319,7 +319,7 @@ class HelsinkiImporter(Importer):
     def import_addresses(self):
         none_to_str = lambda s: s or ""
 
-        wfs_url = 'http://kartta.hel.fi/ws/geoserver/avoindata/wfs?' \
+        wfs_url = 'https://kartta.hel.fi/ws/geoserver/avoindata/wfs?' \
                   'SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&' \
                   'TYPENAME=avoindata:PKS_osoiteluettelo&' \
                   'SRSNAME=EPSG:3067&outputFormat=application/json'
@@ -463,7 +463,7 @@ class HelsinkiImporter(Importer):
         self.logger.info("synchronization complete")
 
     def import_pois(self):
-        URL_BASE = 'http://www.hel.fi/palvelukarttaws/rest/v2/unit/?service=%d'
+        URL_BASE = 'https://www.hel.fi/palvelukarttaws/rest/v2/unit/?service=%d'
 
         muni_dict = {}
         for muni in Municipality.objects.all():


### PR DESCRIPTION
Using http in URLs seems to cause the following error:
>GDAL_ERROR 1: b'GnuTLS recv error (-110): The TLS connection was non-properly terminated.. You may set the CPL_CURL_IGNORE_ERROR configuration option to YES to try to ignore it.'

Changing the URLs to use https *should* fix the issue. Tested locally with Linked Events.
