### PR TITLE
smbackend: Import districts from HSY

### DIFF
--- a/munigeo/data/fi/hsy/config.yml
+++ b/munigeo/data/fi/hsy/config.yml
@@ -46,3 +46,17 @@ divisions:
       origin_id: suur
       ocd_id: nimi
       parent_municipality_id: kunta
+
+  - type: sub_district
+    name: Osa-alue
+    ocd_id: osa-alue
+    no_parent_division: yes
+    parent_ocd_id: 'ocd-division/country:fi'
+    wfs_url: 'https://kartta.hsy.fi/geoserver/wfs'
+    wfs_layer: 'taustakartat_ja_aluejaot:seutukartta_pien_2021'
+    fields:
+      name:
+        fi: nimi
+      origin_id: pien
+      ocd_id: nimi
+      parent_municipality_id: kunta

--- a/munigeo/data/fi/hsy/config.yml
+++ b/munigeo/data/fi/hsy/config.yml
@@ -32,3 +32,17 @@ divisions:
         parent_municipality_id: kunta_nro
         name:
             fi: posno
+
+  - type: major_district
+    name: Suurpiiri
+    ocd_id: suurpiiri
+    no_parent_division: yes
+    parent_ocd_id: 'ocd-division/country:fi'
+    wfs_url: 'https://kartta.hsy.fi/geoserver/wfs'
+    wfs_layer: 'taustakartat_ja_aluejaot:seutukartta_suur_2021'
+    fields:
+      name:
+        fi: nimi
+      origin_id: suur
+      ocd_id: nimi
+      parent_municipality_id: kunta

--- a/munigeo/importer/helsinki.py
+++ b/munigeo/importer/helsinki.py
@@ -161,7 +161,7 @@ class HelsinkiImporter(Importer):
         #
         # import "Pysäköintikielto" (No Parking) as "class 7" for PARKING_CLASS_NAME_MAP to map it as specified.
         #
-        if extra_attr_dict["class"] == "0" and extra_attr_dict["origin_name"] is None:
+        if extra_attr_dict.get("class") == "0" and extra_attr_dict.get("origin_name") is None:
             if feat.get("tyyppi") == "Pysäköintikielto":
                 extra_attr_dict["class"] = "7"
 

--- a/munigeo/importer/hsy.py
+++ b/munigeo/importer/hsy.py
@@ -138,12 +138,16 @@ class HsyImporter(HelsinkiImporter):
                 args = {'parent': div['parent_ocd_id']}
             val = attr_dict['ocd_id']
             args[div['ocd_id']] = val
-            ocd_id = ocd.make_id(**args)
+            try:
+                ocd_id = ocd.make_id(**args)
+            except AttributeError:
+                self.logger.error("Feature: %s is invalid" % feat)
+                return
 
-            # Major districts from Helsinki import should not be overwritten by HSY import
+            # Major and sub-districts from Helsinki import should not be overwritten by HSY import
             if (
                 AdministrativeDivision.objects.filter(
-                    ocd_id=ocd_id, type__type="major_district"
+                    ocd_id=ocd_id, type__type__in=["major_district", "sub_district"]
                 ).exists()
                 and is_new_obj
             ):


### PR DESCRIPTION
Import major and sub-districts from HSY but do not overwrite the ones imported from Helsinki.

Example of change in Palvelukartta UI:

Before only Helsinki districts were visible:
![hel-districts](https://github.com/City-of-Helsinki/django-munigeo/assets/10584178/65c2cff8-1953-429d-b4ec-30aeb3577504)

New districts:
![pk-districts](https://github.com/City-of-Helsinki/django-munigeo/assets/10584178/34f90eee-2634-4e39-af7f-3d555558c7b8)
