### PR TITLE
RATYK-18: Make parent determination conditions less strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- helsinki importer: Make tolerance for divisions extending past their parents relative to parent
+  area (from 300 m^2 to 0.1% of parent area)
+- helsinki importer: Update `statistical_district` WFS layer value
+
 ## [0.3.10]
 ### Fixed
 - Fix Helsinki importer urls

--- a/munigeo/data/fi/helsinki/config.yml
+++ b/munigeo/data/fi/helsinki/config.yml
@@ -275,7 +275,7 @@ divisions:
     no_parent_division: yes
     parent_ocd_id: 'ocd-division/country:fi'
     wfs_url: 'https://kartta.hsy.fi/geoserver/wfs?CQL_FILTER=kunta%20in%20(%27091%27,%27092%27,%27049%27,%27235%27)'
-    wfs_layer: 'taustakartat_ja_aluejaot:seutukartta_pien_2018'
+    wfs_layer: 'taustakartat_ja_aluejaot:seutukartta_pien_2021'
     fields:
         origin_id: kokotun
         ocd_id: kokotun

--- a/munigeo/importer/helsinki.py
+++ b/munigeo/importer/helsinki.py
@@ -133,8 +133,11 @@ class HelsinkiImporter(Importer):
                     parent_geom = parent.geometry.boundary
                     if not geom.intersects(parent_geom):
                         continue
-                    area = (geom - parent.geometry.boundary).area
-                    if area > 1e-6:
+                    # Difference = how much of the area is outside the parent area
+                    area_difference = (geom - parent_geom).area
+                    # The areas must overlap by at least 99.99%,
+                    # i.e. the difference must be less than 0.01%.
+                    if area_difference / geom.area > 0.0001:
                         continue
                     parents.append(parent)
                 if not parents:


### PR DESCRIPTION
Currently, the import fails if an area doesn't have a parent ID and doesn't overlap almost precisely 100% with any other area (<0.000001 whatever units this is using), i.e. the error margin is very, *very* strict. The source data can be a bit inaccurate with the areas. Using relative values rather than absolute values for determining whether an area has enough overlap with a parent area makes the importer work again while still being reasonably accurate (the areas must overlap at least by 99.99%).

No unit tests, unfortunately. This library has a single unit test, so adding tests for this would be a pretty big task.