### PR TITLE
Fix django-modeltranslation >= 0.19.0 compatibility & update setup version

### DIFF
--- a/munigeo/api.py
+++ b/munigeo/api.py
@@ -87,7 +87,7 @@ class TranslatedModelSerializer(serializers.ModelSerializer):
             self.translated_fields = []
             return
 
-        self.translated_fields = trans_opts.fields.keys()
+        self.translated_fields = trans_opts.all_fields.keys()
         lang_codes = [x[0] for x in settings.LANGUAGES]
         remove_fields = []
         # Remove the pre-existing data in the bundle.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-munigeo',
-    version='0.2.85',
+    version='0.2.86',
     packages=['munigeo'],
     include_package_data=True,
     license='BSD License',


### PR DESCRIPTION
In django-modeltranslation version 0.19.0 the `fields` attribute was renamed to `all_fields`:
https://github.com/deschler/django-modeltranslation/blob/master/CHANGELOG.md#-breaking-changes