### PR TITLE
Hsy import: skip division if ocd_id is None

### DIFF
--- a/munigeo/importer/hsy.py
+++ b/munigeo/importer/hsy.py
@@ -142,6 +142,9 @@ class HsyImporter(HelsinkiImporter):
                 args = {'parent': div['parent_ocd_id']}
             val = attr_dict['ocd_id']
             args[div['ocd_id']] = val
+            if not val:
+                self.logger.warning('ocd_id is None. Skipping division...')
+                return
             try:
                 ocd_id = ocd.make_id(**args)
             except AttributeError:


### PR DESCRIPTION
In the hsy import, skip the division if the ocd_id is None and log a warning instead of an error.

[Refs](https://trello.com/c/Tuwc7Rvl/1592-alue-import-tietyt-seutukartat-ovat-virheellisi%C3%A4)