### PR TITLE
Fixes to Uusimaa address importer

### DIFF
--- a/munigeo/importer/uusimaa.py
+++ b/munigeo/importer/uusimaa.py
@@ -90,7 +90,7 @@ class UusimaaImporter(Importer):
     http = requests.Session()
     http.mount("https://", adapter)
     http.mount("http://", adapter)
-    headers = {"Authorization": f"Bearer Api-Key {settings.GEO_SEARCH_API_KEY}"}
+    headers = {"Api-Key": f"{settings.GEO_SEARCH_API_KEY}"}
 
     def __init__(self, *args, **kwargs):
         super(UusimaaImporter, self).__init__(*args, **kwargs)

--- a/munigeo/importer/uusimaa.py
+++ b/munigeo/importer/uusimaa.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.contrib.gis.gdal import CoordTransform, SpatialReference
 from django.contrib.gis.geos import Point
 from django.db import transaction
+from django.utils import timezone
 from munigeo.models import Address, PostalCodeArea, Street, Municipality
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
@@ -258,7 +259,8 @@ class UusimaaImporter(Importer):
                     full_name_fi=full_name_fi,
                     full_name_sv=full_name_sv,
                     full_name_en=full_name_en,
-                    municipality=municipality
+                    municipality=municipality,
+                    modified_at=timezone.now()
                 )
                 addresses.append(address)
                 self.address_cache[full_name_fi] = address


### PR DESCRIPTION
There was a change in Address model that removed `auto_now` setting from `modified_at` field. This caused the import to fail since the `modified_at` field was not set when saving an address in the import. Fix this by setting the `modified_at` field manually.

Also, update geo-search authentication to the new format.
