### PR TITLE
fix: fix broken import

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   test:
     name: Python ${{ matrix.python_version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       TOX_POSARGS: -- --cov=. --cov-report=xml
     strategy:

--- a/munigeo/api.py
+++ b/munigeo/api.py
@@ -1,6 +1,6 @@
-import collections
 import json
 import re
+from collections.abc import Mapping
 from datetime import datetime
 
 from django.conf import settings
@@ -194,7 +194,7 @@ class GeoModelSerializer(serializers.ModelSerializer):
         if obj is None:
             return ret
         for field_name in self.geo_fields:
-            if isinstance(obj, collections.Mapping):
+            if isinstance(obj, Mapping):
                 ret[field_name] = obj
             else:
                 val = getattr(obj, field_name)


### PR DESCRIPTION
collections.Mapping has been deprecated since 3.3 and was removed in 3.10, which causes the import to not work with Python versions >=3.10.

Use collections.abc instead.

Refs: RATYK-85