### PR TITLE
Improve coordinate parsing and validations

### DIFF
--- a/munigeo/api.py
+++ b/munigeo/api.py
@@ -264,10 +264,10 @@ class AdministrativeDivisionSerializer(GeoModelSerializer, TranslatedModelSerial
 def parse_lat_lon(query_params):
     lat = query_params.get('lat', None)
     lon = query_params.get('lon', None)
-    if not lat and not lon:
+    if lat is None and lon is None:
         return None
 
-    if not lat or not lon:
+    if lat is None or lon is None:
         raise ParseError("you must supply both 'lat' and 'lon'")
     try:
         lat = float(lat)
@@ -275,11 +275,29 @@ def parse_lat_lon(query_params):
     except ValueError:
         raise ParseError("'lat' and 'lon' must be floating point numbers")
 
+    # Validate coordinates are within valid ranges for WGS84 (SRID 4326)
+    if not -90 <= lat <= 90:
+        raise ParseError("'lat' must be between -90 and 90")
+    if not -180 <= lon <= 180:
+        raise ParseError("'lon' must be between -180 and 180")
+
+    # Validate coordinates are within valid ranges for Finland if using Finnish SRID
+    if DATABASE_SRID == 3067:
+        if not (59.0 <= lat <= 71.0 and 19.0 <= lon <= 32.0):
+            raise ParseError(
+                "Coordinates (%.6f, %.6f) are outside the valid area for Finland. "
+                "Latitude must be between 59-71°N and longitude between 19-32°E."
+                % (lat, lon)
+            )
+
     point = Point(lon, lat, srid=DEFAULT_SRID)
     if DEFAULT_SRID != DATABASE_SRID:
         ct = CoordTransform(SpatialReference(DEFAULT_SRID),
                             SpatialReference(DATABASE_SRID))
-        point.transform(ct)
+        try:
+            point.transform(ct)
+        except Exception as e:
+            raise ParseError("error transforming coordinates: %s" % str(e))
     return point
 
 

--- a/munigeo/tests/conftest.py
+++ b/munigeo/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import django
 from django.conf import settings
 
@@ -43,6 +44,10 @@ if not settings.configured:
         USE_L10N=True,
         USE_TZ=True,
         STATIC_URL='/static/',
+        PROJECTION_SRID=3067,
+        DEFAULT_SRID=4326,
+        GDAL_LIBRARY_PATH=os.environ.get("GDAL_LIBRARY_PATH"),
+        GEOS_LIBRARY_PATH=os.environ.get("GEOS_LIBRARY_PATH"),
     )
 
     django.setup()

--- a/munigeo/tests/test_coordinates.py
+++ b/munigeo/tests/test_coordinates.py
@@ -1,0 +1,150 @@
+import pytest
+from django.contrib.gis.geos import Point
+from django.http import QueryDict
+from rest_framework.exceptions import ParseError
+from unittest.mock import patch
+from munigeo.api import parse_lat_lon, DATABASE_SRID
+
+
+@pytest.mark.django_db
+class TestParseLatLon:
+    def test_parse_lat_lon_valid_coordinates(self):
+        """Test parsing valid latitude and longitude"""
+        query_params = QueryDict('lat=60.1699&lon=24.9384')
+        point = parse_lat_lon(query_params)
+
+        assert isinstance(point, Point)
+        assert point.srid == DATABASE_SRID
+
+    def test_parse_lat_lon_no_parameters(self):
+        """Test returns None when no lat/lon provided"""
+        query_params = QueryDict('')
+        result = parse_lat_lon(query_params)
+
+        assert result is None
+
+    def test_parse_lat_lon_missing_lat(self):
+        """Test raises error when only lon is provided"""
+        query_params = QueryDict('lon=24.9384')
+
+        with pytest.raises(ParseError) as exc:
+            parse_lat_lon(query_params)
+
+        assert "both 'lat' and 'lon'" in str(exc.value)
+
+    def test_parse_lat_lon_missing_lon(self):
+        """Test raises error when only lat is provided"""
+        query_params = QueryDict('lat=60.1699')
+
+        with pytest.raises(ParseError) as exc:
+            parse_lat_lon(query_params)
+
+        assert "both 'lat' and 'lon'" in str(exc.value)
+
+    def test_parse_lat_lon_invalid_lat_format(self):
+        """Test raises error for non-numeric latitude"""
+        query_params = QueryDict('lat=invalid&lon=24.9384')
+
+        with pytest.raises(ParseError) as exc:
+            parse_lat_lon(query_params)
+
+        assert "floating point numbers" in str(exc.value)
+
+    def test_parse_lat_lon_invalid_lon_format(self):
+        """Test raises error for non-numeric longitude"""
+        query_params = QueryDict('lat=60.1699&lon=invalid')
+
+        with pytest.raises(ParseError) as exc:
+            parse_lat_lon(query_params)
+
+        assert "floating point numbers" in str(exc.value)
+
+    def test_parse_lat_lon_lat_out_of_range_high(self):
+        """Test raises error when latitude > 90"""
+        query_params = QueryDict('lat=91.0&lon=24.9384')
+
+        with pytest.raises(ParseError) as exc:
+            parse_lat_lon(query_params)
+
+        assert "between -90 and 90" in str(exc.value)
+
+    def test_parse_lat_lon_lat_out_of_range_low(self):
+        """Test raises error when latitude < -90"""
+        query_params = QueryDict('lat=-91.0&lon=24.9384')
+
+        with pytest.raises(ParseError) as exc:
+            parse_lat_lon(query_params)
+
+        assert "between -90 and 90" in str(exc.value)
+
+    def test_parse_lat_lon_lon_out_of_range_high(self):
+        """Test raises error when longitude > 180"""
+        query_params = QueryDict('lat=60.1699&lon=181.0')
+
+        with pytest.raises(ParseError) as exc:
+            parse_lat_lon(query_params)
+
+        assert "between -180 and 180" in str(exc.value)
+
+    def test_parse_lat_lon_lon_out_of_range_low(self):
+        """Test raises error when longitude < -180"""
+        query_params = QueryDict('lat=60.1699&lon=-181.0')
+
+        with pytest.raises(ParseError) as exc:
+            parse_lat_lon(query_params)
+
+        assert "between -180 and 180" in str(exc.value)
+
+    @pytest.mark.skipif(
+        DATABASE_SRID != 3067,
+        reason="Only applies to Finnish coordinate systems"
+    )
+    def test_parse_lat_lon_outside_finland_bounds(self):
+        """Test raises error for coordinates outside Finland"""
+        query_params = QueryDict('lat=40.0&lon=10.0')
+
+        with pytest.raises(ParseError) as exc:
+            parse_lat_lon(query_params)
+
+        assert "outside the valid area for Finland" in str(exc.value)
+
+    @pytest.mark.skipif(
+        DATABASE_SRID != 3067,
+        reason="Only applies to Finnish coordinate systems"
+    )
+    def test_parse_lat_lon_within_finland_bounds(self):
+        """Test valid coordinates within Finland bounds"""
+        query_params = QueryDict('lat=60.1699&lon=24.9384')
+        point = parse_lat_lon(query_params)
+
+        assert point is not None
+        assert isinstance(point, Point)
+
+    @patch('munigeo.api.DATABASE_SRID', 4326)
+    def test_parse_lat_lon_boundary_values(self):
+        """Test coordinates at valid boundaries"""
+        query_params = QueryDict('lat=90&lon=180')
+        point = parse_lat_lon(query_params)
+        assert point is not None
+
+        query_params = QueryDict('lat=-90&lon=-180')
+        point = parse_lat_lon(query_params)
+        assert point is not None
+
+    def test_parse_lat_lon_coordinate_transformation(self):
+        """Test coordinate transformation when DEFAULT_SRID != DATABASE_SRID"""
+        query_params = QueryDict('lat=60.1699&lon=24.9384')
+        point = parse_lat_lon(query_params)
+
+        assert point.srid == DATABASE_SRID
+
+    def test_parse_lat_lon_zero_coordinates(self):
+        """Test that 0 is treated as a valid coordinate value"""
+        query_params = QueryDict('lat=0&lon=0')
+
+        with patch('munigeo.api.DATABASE_SRID', 4326):
+            point = parse_lat_lon(query_params)
+
+        assert point is not None
+        assert point.x == pytest.approx(0.0)
+        assert point.y == pytest.approx(0.0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=3.1
+Django>=4.2
 djangorestframework
 requests
 django-mptt
@@ -6,4 +6,7 @@ django-modeltranslation
 six
 pyyaml
 unicodecsv
-psycopg2<2.9
+psycopg[c]
+pip-tools
+pytest-django
+pytest-cov


### PR DESCRIPTION
Updates:
- Validate coordinates are within valid ranges for WGS84 (SRID 4326) and ETRS-TM35FIN (SRID 3067) when it is used
- Raise ParseError if coordinate transformation fails
- Update conftest settings for a better API-test usage
- Add tests for coordinate parsing
- Improve coordinate validation to compare with None to make 0-coordinates work also
- Use psycopg[c]
- Add pip-tools, pytest-django and pytest-cov
- Bump Django minimum version to 4.2

Refs: [RATYK-147](https://helsinkisolutionoffice.atlassian.net/browse/RATYK-147)

[RATYK-147]: https://helsinkisolutionoffice.atlassian.net/browse/RATYK-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ