### PR TITLE
Allow usage of dynamic import data path in data imports

### DIFF
--- a/munigeo/importer/base.py
+++ b/munigeo/importer/base.py
@@ -60,14 +60,17 @@ class Importer(object):
     def __init__(self, options):
         self.logger = logging.getLogger("import")
 
-        if hasattr(settings, 'PROJECT_ROOT'):
-            root_dir = settings.PROJECT_ROOT
+        if getattr(settings, 'IMPORT_DATA_PATH', None):
+            self.data_paths = [settings.IMPORT_DATA_PATH]
         else:
-            root_dir = settings.BASE_DIR
-        self.data_paths = [os.path.join(root_dir, 'data')]
-        module_path = os.path.dirname(__file__)
-        app_path = os.path.abspath(os.path.join(module_path, '..', 'data'))
-        self.data_paths.append(app_path)
+            if hasattr(settings, 'PROJECT_ROOT'):
+                root_dir = settings.PROJECT_ROOT
+            else:
+                root_dir = settings.BASE_DIR
+            self.data_paths = [os.path.join(root_dir, 'data')]
+            module_path = os.path.dirname(__file__)
+            app_path = os.path.abspath(os.path.join(module_path, '..', 'data'))
+            self.data_paths.append(app_path)
 
         self.options = options
 


### PR DESCRIPTION
Allow usage of dynamic import data path in data imports.

When `IMPORT_DATA_PATH` is set in settings, it will be used.

Refs: [RATYK-148](https://helsinkisolutionoffice.atlassian.net/browse/RATYK-148)

[RATYK-148]: https://helsinkisolutionoffice.atlassian.net/browse/RATYK-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ