### PR TITLE
Fix issues with data paths

### DIFF
--- a/munigeo/importer/base.py
+++ b/munigeo/importer/base.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 import os
 import requests
 import json
@@ -17,20 +18,25 @@ def convert_from_wgs84(coords):
 class Importer(object):
     def __init__(self, options):
         self.logger = logging.getLogger("import")
-
-        if getattr(settings, 'IMPORT_DATA_PATH', None):
-            self.data_paths = [settings.IMPORT_DATA_PATH]
-        else:
-            if hasattr(settings, 'PROJECT_ROOT'):
-                root_dir = settings.PROJECT_ROOT
-            else:
-                root_dir = settings.BASE_DIR
-            self.data_paths = [os.path.join(root_dir, 'data')]
-            module_path = os.path.dirname(__file__)
-            app_path = os.path.abspath(os.path.join(module_path, '..', 'data'))
-            self.data_paths.append(app_path)
-
         self.options = options
+
+    @cached_property
+    def data_paths(self):
+        data_paths = []
+        if getattr(settings, 'IMPORT_DATA_PATH', None):
+            data_paths.append(settings.IMPORT_DATA_PATH)
+
+        if hasattr(settings, 'PROJECT_ROOT'):
+            root_dir = settings.PROJECT_ROOT
+        else:
+            root_dir = settings.BASE_DIR
+        data_paths.append(os.path.join(root_dir, 'data'))
+
+        module_path = os.path.dirname(__file__)
+        app_path = os.path.abspath(os.path.join(module_path, '..', 'data'))
+        data_paths.append(app_path)
+
+        return data_paths
 
     def _import_citadel(self, muni, info):
         muni_slug = slugify(muni.name)

--- a/munigeo/importer/base.py
+++ b/munigeo/importer/base.py
@@ -37,6 +37,18 @@ class Importer(object):
         data_paths.append(app_path)
 
         return data_paths
+    
+    @property
+    def import_data_path(self):
+        """
+        Path for storing temporary data for imports.
+
+        If set, uses IMPORT_DATA_PATH. Otherwise, uses the first data path 
+        set in data_paths (which should be either PROJECT_ROOT or BASE_DIR).
+        """
+        if getattr(settings, "IMPORT_DATA_PATH", None):
+            return settings.IMPORT_DATA_PATH
+        return self.data_paths[0]
 
     def _import_citadel(self, muni, info):
         muni_slug = slugify(muni.name)

--- a/munigeo/importer/base.py
+++ b/munigeo/importer/base.py
@@ -15,6 +15,23 @@ def convert_from_wgs84(coords):
 
 
 class Importer(object):
+    def __init__(self, options):
+        self.logger = logging.getLogger("import")
+
+        if getattr(settings, 'IMPORT_DATA_PATH', None):
+            self.data_paths = [settings.IMPORT_DATA_PATH]
+        else:
+            if hasattr(settings, 'PROJECT_ROOT'):
+                root_dir = settings.PROJECT_ROOT
+            else:
+                root_dir = settings.BASE_DIR
+            self.data_paths = [os.path.join(root_dir, 'data')]
+            module_path = os.path.dirname(__file__)
+            app_path = os.path.abspath(os.path.join(module_path, '..', 'data'))
+            self.data_paths.append(app_path)
+
+        self.options = options
+
     def _import_citadel(self, muni, info):
         muni_slug = slugify(muni.name)
 
@@ -56,23 +73,6 @@ class Importer(object):
             if os.path.exists(full_path):
                 return full_path
         raise FileNotFoundError("Data file '%s' not found" % data_file)
-
-    def __init__(self, options):
-        self.logger = logging.getLogger("import")
-
-        if getattr(settings, 'IMPORT_DATA_PATH', None):
-            self.data_paths = [settings.IMPORT_DATA_PATH]
-        else:
-            if hasattr(settings, 'PROJECT_ROOT'):
-                root_dir = settings.PROJECT_ROOT
-            else:
-                root_dir = settings.BASE_DIR
-            self.data_paths = [os.path.join(root_dir, 'data')]
-            module_path = os.path.dirname(__file__)
-            app_path = os.path.abspath(os.path.join(module_path, '..', 'data'))
-            self.data_paths.append(app_path)
-
-        self.options = options
 
 
 importers = {}

--- a/munigeo/importer/finland.py
+++ b/munigeo/importer/finland.py
@@ -96,7 +96,7 @@ class FinlandImporter(Importer):
                     break
             else:
                 raise Exception('XML file not found in %s' % MUNI_DATA_URL)
-            out_path = os.path.join(self.data_paths[0], 'fi')
+            out_path = os.path.join(self.import_data_path, 'fi')
             try:
                 os.makedirs(out_path)
             except OSError:

--- a/munigeo/tests/test_base_importer.py
+++ b/munigeo/tests/test_base_importer.py
@@ -47,3 +47,15 @@ class TestDataPaths:
         settings.BASE_DIR = "base_dir"
 
         assert "base_dir/data" in importer.data_paths
+
+    def test_import_data_path_returns_import_data_path_if_set(self, importer, settings):
+        settings.IMPORT_DATA_PATH = "import_data_path"
+
+        assert importer.import_data_path == "import_data_path"
+
+    def test_import_data_path_returns_first_data_path_by_default(
+        self, importer, settings
+    ):
+        settings.PROJECT_ROOT = "project_root"
+
+        assert importer.import_data_path == "project_root/data"

--- a/munigeo/tests/test_base_importer.py
+++ b/munigeo/tests/test_base_importer.py
@@ -1,0 +1,49 @@
+from munigeo.importer.base import Importer
+import pytest
+
+
+@pytest.fixture
+def importer():
+    return Importer(options={})
+
+
+class TestDataPaths:
+    @pytest.mark.parametrize("project_root", ["project_root", ""])
+    @pytest.mark.parametrize("base_dir", ["base_dir", ""])
+    def test_import_data_path_is_always_included_if_set(
+        self, importer, settings, project_root, base_dir
+    ):
+        if project_root:
+            settings.PROJECT_ROOT = project_root
+        settings.BASE_DIR = base_dir
+        settings.IMPORT_DATA_PATH = "import_data_path"
+
+        assert "import_data_path" in importer.data_paths
+
+    @pytest.mark.parametrize("project_root", ["project_root", ""])
+    @pytest.mark.parametrize("base_dir", ["base_dir", ""])
+    @pytest.mark.parametrize("import_data_path", ["import_data_path", ""])
+    def test_app_path_is_always_included(
+        self, importer, settings, project_root, base_dir, import_data_path
+    ):
+        if project_root:
+            settings.PROJECT_ROOT = project_root
+        settings.BASE_DIR = base_dir
+        settings.IMPORT_DATA_PATH = import_data_path
+
+        assert any("/munigeo/data" in data_path for data_path in importer.data_paths)
+
+    @pytest.mark.parametrize("base_dir", ["base_dir", ""])
+    def test_project_root_prioritized_over_base_dir(self, importer, settings, base_dir):
+        settings.PROJECT_ROOT = "project_root"
+        settings.BASE_DIR = base_dir
+
+        assert "project_root/data" in importer.data_paths
+        assert f"{base_dir}/data" not in importer.data_paths
+
+    def test_include_base_dir_if_no_project_root(self, importer, settings):
+        # PROJECT_ROOT needs to literally not exist in this case.
+        del settings.PROJECT_ROOT
+        settings.BASE_DIR = "base_dir"
+
+        assert "base_dir/data" in importer.data_paths


### PR DESCRIPTION
A previous fix introduced a new setting for data path called IMPORT_DATA_PATH, which resolved the issue of downloading and extracting files in systems where the importer's permissions are more restricted. This introduced a new bug: using IMPORT_DATA_PATH over PROJECT_ROOT/BASE_DIR in every case breaks functionality in other importers.

This PR fixes the issue by adding two new properties in the base importer:
- `Importer.data_paths`, which includes all data paths for *reading* data
- `Importer.import_data_path`, which is the data path for *writing* data (i.e. `IMPORT_DATA_PATH` if set, `Importer.data_paths[0]` otherwise)

Note that this PR aims to retain as much of the existing behavior as possible. The test coverage isn't perfect either as the library isn't exactly test-friendly and resolving that issue is a whole other can of worms.

Refs: RATYK-155