### PR TITLE
ci: unify sonar-project.properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey=City-of-Helsinki_django-munigeo
+sonar.organization=city-of-helsinki
+sonar.python.version=3.10
+sonar.python.coverage.reportPaths=coverage.xml
+sonar.test.inclusions=**/tests/**/*
+sonar.exclusions=**/migrations/*,pipelines/**/*


### PR DESCRIPTION
Add `sonar-project.properties` to align with other City-of-Helsinki Python repos.

Refs: KEH-189