### PR TITLE
chore: add project name, version and python version to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[project]
+name = "django-munigeo"
+requires-python = ">=3.10"
+version = "0.3.12"
+
 [tool.ruff]
 target-version = "py310"
 


### PR DESCRIPTION
Add `[project]` section with `name`, `version` and `requires-python` to `pyproject.toml`.

Refs: KEH-241