### PR TITLE
1.0: enable ruff lint rules and apply fixes

### DIFF
--- a/munigeo/importer/helsinki.py
+++ b/munigeo/importer/helsinki.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from django.contrib.gis import gdal
 from django.contrib.gis.gdal import CoordTransform, DataSource, SpatialReference
 from django.contrib.gis.gdal.srs import AxisOrder  # requires django 3.1
-from django.contrib.gis.geos import GEOSGeometry, MultiPolygon, Point
+from django.contrib.gis.geos import GEOSGeometry, MultiPolygon
 from django.utils import timezone
 
 from munigeo import ocd

--- a/munigeo/management/commands/update_parking_areas.py
+++ b/munigeo/management/commands/update_parking_areas.py
@@ -3,7 +3,6 @@ This management command updates parking areas according to new desired specifica
 """
 
 from time import time
-from typing import List
 
 from django.core.management.base import BaseCommand
 

--- a/munigeo/management/commands/update_postal_code_areas.py
+++ b/munigeo/management/commands/update_postal_code_areas.py
@@ -118,7 +118,7 @@ class Command(BaseCommand):
         results_queue = Queue()
         url = self.base_url
 
-        self.logger.info(f"Fetching postal code areas...")
+        self.logger.info("Fetching postal code areas...")
         count = self.get_count(url)
         max_page = int(count / PAGE_SIZE) + 1
         self.logger.info(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,20 +124,21 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = [
-    # pycodestyle - style only
+    # Pyflakes
+    "F",
+    # pycodestyle
     "E",
     "W",
     # isort
     "I",
-    # The checks below are intentionally disabled during the 0.2/main branch merge
-    # preparation. Fixing the issues they surface would diverge the branches further,
-    # making the eventual merge harder. Re-enable once the branches are unified.
-    #
-    # "F",    # Pyflakes - undefined names, unused imports/variables (real bugs)
-    # "N",    # pep8-naming - naming convention violations
-    # "B0",   # flake8-bugbear (non-opinionated) - likely bugs and design issues
-    # "PIE",  # flake8-pie - misc code style improvements
-    # "T20",  # flake8-print - print() statements
+    # pep8-naming
+    "N",
+    # flake8-bugbear without opinionated rules
+    "B0",
+    # flake8-pie
+    "PIE",
+    # flake8-print
+    "T20",
 ]
 ignore = [
     # Long lines are not auto-fixable and too noisy on legacy code; re-evaluate

--- a/test_app/admin.py
+++ b/test_app/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
-
 # Register your models here.

--- a/test_app/models.py
+++ b/test_app/models.py
@@ -1,3 +1,1 @@
-from django.db import models
-
 # Create your models here.

--- a/test_app/tests/test_address_municipality_migration.py
+++ b/test_app/tests/test_address_municipality_migration.py
@@ -23,11 +23,11 @@ def test_address_municipality_populated_from_street(migration_executor):
     apps = state.apps
 
     # Create test data using historical models (pre-0010: no municipality on Address)
-    DivisionType = apps.get_model("munigeo", "AdministrativeDivisionType")
-    Division = apps.get_model("munigeo", "AdministrativeDivision")
-    Municipality = apps.get_model("munigeo", "Municipality")
-    Street = apps.get_model("munigeo", "Street")
-    Address = apps.get_model("munigeo", "Address")
+    DivisionType = apps.get_model("munigeo", "AdministrativeDivisionType")  # noqa: N806
+    Division = apps.get_model("munigeo", "AdministrativeDivision")  # noqa: N806
+    Municipality = apps.get_model("munigeo", "Municipality")  # noqa: N806
+    Street = apps.get_model("munigeo", "Street")  # noqa: N806
+    Address = apps.get_model("munigeo", "Address")  # noqa: N806
 
     div_type = DivisionType.objects.create(type="muni", name="Municipality")
     div = Division.objects.create(
@@ -95,11 +95,11 @@ def test_address_municipality_multiple_municipalities(migration_executor):
     executor.loader.build_graph()
     apps = state.apps
 
-    DivisionType = apps.get_model("munigeo", "AdministrativeDivisionType")
-    Division = apps.get_model("munigeo", "AdministrativeDivision")
-    Municipality = apps.get_model("munigeo", "Municipality")
-    Street = apps.get_model("munigeo", "Street")
-    Address = apps.get_model("munigeo", "Address")
+    DivisionType = apps.get_model("munigeo", "AdministrativeDivisionType")  # noqa: N806
+    Division = apps.get_model("munigeo", "AdministrativeDivision")  # noqa: N806
+    Municipality = apps.get_model("munigeo", "Municipality")  # noqa: N806
+    Street = apps.get_model("munigeo", "Street")  # noqa: N806
+    Address = apps.get_model("munigeo", "Address")  # noqa: N806
 
     div_type = DivisionType.objects.create(type="muni", name="Municipality")
 

--- a/test_app/tests/test_parler_data_migration.py
+++ b/test_app/tests/test_parler_data_migration.py
@@ -40,7 +40,7 @@ def _fixture_sort_key(obj):
     - Then municipalities (which reference those divisions)
     - Then divisions with a municipality FK (sub-divisions)
     """
-    MODEL_ORDER = {
+    model_order = {
         "munigeo.administrativedivisiontype": 0,
         "munigeo.administrativedivision": 10,  # refined below
         "munigeo.municipality": 20,
@@ -49,7 +49,7 @@ def _fixture_sort_key(obj):
         "munigeo.municipalitytranslation": 40,
         "munigeo.streettranslation": 40,
     }
-    order = MODEL_ORDER.get(obj["model"], 99)
+    order = model_order.get(obj["model"], 99)
 
     # Within divisions, those without municipality FK must come before
     # municipalities, and those with municipality FK must come after.
@@ -117,7 +117,7 @@ def test_parler_data_migration_forward(migration_executor):
     apps = state.apps
 
     # Verify AdministrativeDivision names were copied
-    Division = apps.get_model("munigeo", "AdministrativeDivision")
+    Division = apps.get_model("munigeo", "AdministrativeDivision")  # noqa: N806
     for origin_id, (expected_fi, expected_sv) in EXPECTED_DIVISION_NAMES.items():
         div = Division.objects.get(origin_id=origin_id)
         assert div.name_fi == expected_fi, (
@@ -128,7 +128,7 @@ def test_parler_data_migration_forward(migration_executor):
         )
 
     # Verify Municipality names were copied
-    Municipality = apps.get_model("munigeo", "Municipality")
+    Municipality = apps.get_model("munigeo", "Municipality")  # noqa: N806
     for pk, (expected_fi, expected_sv) in EXPECTED_MUNICIPALITY_NAMES.items():
         muni = Municipality.objects.get(pk=pk)
         assert muni.name_fi == expected_fi, (
@@ -165,9 +165,9 @@ def test_parler_data_migration_backward(migration_executor):
     apps = state.apps
 
     # Verify translation rows were recreated
-    DivisionTranslation = apps.get_model("munigeo", "AdministrativeDivisionTranslation")
+    DivisionTranslation = apps.get_model("munigeo", "AdministrativeDivisionTranslation")  # noqa: N806
     for origin_id, (expected_fi, expected_sv) in EXPECTED_DIVISION_NAMES.items():
-        Division = apps.get_model("munigeo", "AdministrativeDivision")
+        Division = apps.get_model("munigeo", "AdministrativeDivision")  # noqa: N806
         div = Division.objects.get(origin_id=origin_id)
 
         fi_trans = DivisionTranslation.objects.get(master_id=div.pk, language_code="fi")
@@ -176,7 +176,7 @@ def test_parler_data_migration_backward(migration_executor):
         sv_trans = DivisionTranslation.objects.get(master_id=div.pk, language_code="sv")
         assert sv_trans.name == expected_sv
 
-    MuniTranslation = apps.get_model("munigeo", "MunicipalityTranslation")
+    MuniTranslation = apps.get_model("munigeo", "MunicipalityTranslation")  # noqa: N806
     for pk, (expected_fi, expected_sv) in EXPECTED_MUNICIPALITY_NAMES.items():
         fi_trans = MuniTranslation.objects.get(master_id=pk, language_code="fi")
         assert fi_trans.name == expected_fi

--- a/test_app/tests/test_uusimaa_importer.py
+++ b/test_app/tests/test_uusimaa_importer.py
@@ -271,7 +271,7 @@ def test_missing_sv_name_falls_back_to_fi(porvoo, uusimaa_importer):
 def test_missing_municipality_is_skipped(uusimaa_importer, caplog):
     """import_addresses skips municipalities not in DB."""
     # Don't create any Municipality objects - all should be skipped
-    with rm.Mocker() as m:
+    with rm.Mocker():
         uusimaa_importer.import_addresses()
 
     assert Street.objects.count() == 0

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -1,3 +1,1 @@
-from django.shortcuts import render
-
 # Create your views here.


### PR DESCRIPTION
Enable the ruff linting rules on again and apply fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up internal imports and removed unused dependencies across multiple modules
  * Removed unused framework imports from test application files
  * Updated linting configuration to enforce additional code quality standards

* **Tests**
  * Refactored migration tests to properly use Django's app registry for accessing model versions
  * Simplified test setup procedures for address and postal code importers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->